### PR TITLE
fix: throws/reject typings

### DIFF
--- a/src/assert.ts
+++ b/src/assert.ts
@@ -11,7 +11,7 @@ import { assert, Assertion } from 'chai'
 import Macroable from '@poppinss/macroable'
 import { AssertionError } from 'assertion-error'
 
-import type { AssertContract, ChaiAssert } from './types.js'
+import type { AnyErrorConstructor, AssertContract, ChaiAssert } from './types.js'
 
 /**
  * The Assert class is derived from chai.assert to allow support
@@ -1170,16 +1170,16 @@ export class Assert extends Macroable implements AssertContract {
    * assert.throws(foo, 'failed') // fails
    */
   throws(fn: () => void, message?: string): void
-  throws(fn: () => void, errType: RegExp | ErrorConstructor, message?: string): void
+  throws(fn: () => void, errType: RegExp | AnyErrorConstructor, message?: string): void
   throws(
     fn: () => void,
-    constructor: ErrorConstructor,
+    constructor: AnyErrorConstructor,
     regExp: RegExp | string,
     message?: string
   ): void
   throws(
     fn: () => void,
-    errType?: RegExp | ErrorConstructor | string,
+    errType?: RegExp | AnyErrorConstructor | string,
     regExp?: RegExp | string,
     message?: string
   ): void {
@@ -1203,16 +1203,16 @@ export class Assert extends Macroable implements AssertContract {
    */
   doesNotThrow(fn: () => void, message?: string): void
   doesNotThrow(fn: () => void, regExp: RegExp): void
-  doesNotThrow(fn: () => void, constructor: ErrorConstructor, message?: string): void
+  doesNotThrow(fn: () => void, constructor: AnyErrorConstructor, message?: string): void
   doesNotThrow(
     fn: () => void,
-    constructor: ErrorConstructor,
+    constructor: AnyErrorConstructor,
     regExp: RegExp | string,
     message?: string
   ): void
   doesNotThrow(
     fn: () => void,
-    errType?: RegExp | ErrorConstructor | string,
+    errType?: RegExp | AnyErrorConstructor | string,
     regExp?: RegExp | string,
     message?: string
   ): void {
@@ -1919,18 +1919,18 @@ export class Assert extends Macroable implements AssertContract {
   async rejects(fn: () => void, message?: string): Promise<void>
   async rejects(
     fn: () => void | Promise<void>,
-    errType: RegExp | ErrorConstructor,
+    errType: RegExp | AnyErrorConstructor,
     message?: string
   ): Promise<void>
   async rejects(
     fn: () => void | Promise<void>,
-    constructor: ErrorConstructor,
+    constructor: AnyErrorConstructor,
     regExp: RegExp | string,
     message?: string
   ): Promise<void>
   async rejects(
     fn: () => void | Promise<void>,
-    errType?: RegExp | ErrorConstructor | string,
+    errType?: RegExp | AnyErrorConstructor | string,
     regExp?: RegExp | string,
     message?: string
   ): Promise<void> {
@@ -2059,18 +2059,18 @@ export class Assert extends Macroable implements AssertContract {
   async doesNotReject(fn: () => void, message?: string): Promise<void>
   async doesNotReject(
     fn: () => void | Promise<void>,
-    errType: RegExp | ErrorConstructor,
+    errType: RegExp | AnyErrorConstructor,
     message?: string
   ): Promise<void>
   async doesNotReject(
     fn: () => void | Promise<void>,
-    constructor: ErrorConstructor,
+    constructor: AnyErrorConstructor,
     regExp: RegExp | string,
     message?: string
   ): Promise<void>
   async doesNotReject(
     fn: () => void | Promise<void>,
-    errType?: RegExp | ErrorConstructor | string,
+    errType?: RegExp | AnyErrorConstructor | string,
     regExp?: RegExp | string,
     message?: string
   ): Promise<void> {

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -1169,16 +1169,16 @@ export class Assert extends Macroable implements AssertContract {
    * assert.throws(foo, 'blow up') // passes
    * assert.throws(foo, 'failed') // fails
    */
-  throws(fn: () => void, message?: string): void
-  throws(fn: () => void, errType: RegExp | AnyErrorConstructor, message?: string): void
+  throws(fn: () => unknown, message?: string): void
+  throws(fn: () => unknown, errType: RegExp | AnyErrorConstructor, message?: string): void
   throws(
-    fn: () => void,
+    fn: () => unknown,
     constructor: AnyErrorConstructor,
     regExp: RegExp | string,
     message?: string
   ): void
   throws(
-    fn: () => void,
+    fn: () => unknown,
     errType?: RegExp | AnyErrorConstructor | string,
     regExp?: RegExp | string,
     message?: string
@@ -1201,17 +1201,17 @@ export class Assert extends Macroable implements AssertContract {
    * assert.doesNotThrow(foo, 'failed') // passes
    * assert.doesNotThrow(() => {}) // passes
    */
-  doesNotThrow(fn: () => void, message?: string): void
-  doesNotThrow(fn: () => void, regExp: RegExp): void
-  doesNotThrow(fn: () => void, constructor: AnyErrorConstructor, message?: string): void
+  doesNotThrow(fn: () => unknown, message?: string): void
+  doesNotThrow(fn: () => unknown, regExp: RegExp): void
+  doesNotThrow(fn: () => unknown, constructor: AnyErrorConstructor, message?: string): void
   doesNotThrow(
-    fn: () => void,
+    fn: () => unknown,
     constructor: AnyErrorConstructor,
     regExp: RegExp | string,
     message?: string
   ): void
   doesNotThrow(
-    fn: () => void,
+    fn: () => unknown,
     errType?: RegExp | AnyErrorConstructor | string,
     regExp?: RegExp | string,
     message?: string
@@ -1916,20 +1916,20 @@ export class Assert extends Macroable implements AssertContract {
    * @example
    * await assert.reject(() => throw new Error(''))
    */
-  async rejects(fn: () => void, message?: string): Promise<void>
+  async rejects(fn: () => unknown, message?: string): Promise<void>
   async rejects(
-    fn: () => void | Promise<void>,
+    fn: () => unknown | Promise<unknown>,
     errType: RegExp | AnyErrorConstructor,
     message?: string
   ): Promise<void>
   async rejects(
-    fn: () => void | Promise<void>,
+    fn: () => unknown | Promise<unknown>,
     constructor: AnyErrorConstructor,
     regExp: RegExp | string,
     message?: string
   ): Promise<void>
   async rejects(
-    fn: () => void | Promise<void>,
+    fn: () => unknown | Promise<unknown>,
     errType?: RegExp | AnyErrorConstructor | string,
     regExp?: RegExp | string,
     message?: string
@@ -2056,20 +2056,20 @@ export class Assert extends Macroable implements AssertContract {
    *   async () => return 'foo',
    * ) // passes
    */
-  async doesNotReject(fn: () => void, message?: string): Promise<void>
+  async doesNotReject(fn: () => unknown, message?: string): Promise<void>
   async doesNotReject(
-    fn: () => void | Promise<void>,
+    fn: () => unknown | Promise<unknown>,
     errType: RegExp | AnyErrorConstructor,
     message?: string
   ): Promise<void>
   async doesNotReject(
-    fn: () => void | Promise<void>,
+    fn: () => unknown | Promise<unknown>,
     constructor: AnyErrorConstructor,
     regExp: RegExp | string,
     message?: string
   ): Promise<void>
   async doesNotReject(
-    fn: () => void | Promise<void>,
+    fn: () => unknown | Promise<unknown>,
     errType?: RegExp | AnyErrorConstructor | string,
     regExp?: RegExp | string,
     message?: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,3 +75,9 @@ export type AssertContract = Omit<
 >
 
 export type PluginConfig = {}
+
+/**
+ * A more flexible error constructor than `ErrorConstructor` type that allows custom
+ * error classes with any constructor signature
+ */
+export type AnyErrorConstructor = new (...args: any[]) => Error

--- a/tests/assert/assert.spec.ts
+++ b/tests/assert/assert.spec.ts
@@ -1665,6 +1665,17 @@ test.describe('assert', function () {
     }, "expected [Function] to throw 'TypeError' but 'Error: Internal Server Error' was thrown")
   })
 
+  test('throws with function returning non-void value', function () {
+    const assert = new Assert()
+
+    function myThing(): string {
+      throw new Error('Something went wrong')
+    }
+
+    assert.throws(() => myThing(), Error)
+    assert.throws(() => myThing(), 'Something went wrong')
+  })
+
   test('rejects', async function () {
     const assert = new Assert()
 

--- a/tests/assert/assert.spec.ts
+++ b/tests/assert/assert.spec.ts
@@ -1634,6 +1634,37 @@ test.describe('assert', function () {
     }, 'blah: expected {} to be a function')
   })
 
+  test('throws with custom error constructor with multiple arguments', function () {
+    const assert = new Assert()
+
+    class CustomError extends Error {
+      constructor(
+        public code: number,
+        message: string
+      ) {
+        super(message)
+      }
+    }
+
+    assert.throws(() => {
+      throw new CustomError(500, 'Internal Server Error')
+    }, CustomError)
+
+    assert.throws(
+      () => {
+        throw new CustomError(404, 'Not Found')
+      },
+      CustomError,
+      'Not Found'
+    )
+
+    expectError(() => {
+      assert.throws(() => {
+        throw new CustomError(500, 'Internal Server Error')
+      }, TypeError)
+    }, "expected [Function] to throw 'TypeError' but 'Error: Internal Server Error' was thrown")
+  })
+
   test('rejects', async function () {
     const assert = new Assert()
 
@@ -1727,6 +1758,42 @@ test.describe('assert', function () {
     await expectAsyncError(async function () {
       await assert.rejects({} as any, Error, 'testing', 'blah')
     }, 'blah: expected {} to be a function')
+  })
+
+  test('rejects with custom error constructor with multiple arguments', async function () {
+    const assert = new Assert()
+
+    class CustomError extends Error {
+      constructor(
+        public code: number,
+        message: string
+      ) {
+        super(message)
+      }
+    }
+
+    await assert.rejects(async function () {
+      throw new CustomError(500, 'Internal Server Error')
+    }, CustomError)
+
+    await assert.rejects(
+      async function () {
+        throw new CustomError(404, 'Not Found')
+      },
+      CustomError,
+      'Not Found'
+    )
+  })
+
+  test('rejects with function returning non-void value', async function () {
+    const assert = new Assert()
+
+    async function myThing(): Promise<string> {
+      throw new Error('Something went wrong')
+    }
+
+    await assert.rejects(() => myThing(), Error)
+    await assert.rejects(() => myThing(), 'Something went wrong')
   })
 
   test('doesNotThrows', function () {


### PR DESCRIPTION
those typings were way too strict
before the PR, TS complained about this :

```ts
// TS complains because the function doesnt return `void`
await assert.rejects(() => myFunctionReturningAString())

// TS complains when using an Error constructor that accepts args other than raw Error,
// like the one from poppins/exceptions
await assert.rejects(() => something(), E_MY_ERROR)
```
